### PR TITLE
Speed up optimization with gains reordering

### DIFF
--- a/calico/tests.py
+++ b/calico/tests.py
@@ -1101,7 +1101,7 @@ class TestStringMethods(unittest.TestCase):
                 np.real(gains_init[:, test_freq_ind]),
                 np.imag(gains_init[:, test_freq_ind]),
             ),
-            axis=0,
+            axis=1,
         ).flatten()
 
         hess = calibration_optimization.hessian_skycal_wrapper(


### PR DESCRIPTION
Memory is happier when the real and imaginary components of the gains are next to one another in the flattened gain array. This means that the array is ordered [Re(g1), Im(g1), Re(g2), Im(g2), ...] rather than [Re(g1), Re(g2), ..., Im(g1), Im(g2), ...].