### PR TITLE
Restructure/refactor to accommodate UniCal

### DIFF
--- a/calico/caldata.py
+++ b/calico/caldata.py
@@ -1241,3 +1241,20 @@ class CalData:
                     weight_mat[time_ind, :, :, :, vis_pol_ind] *= normalization_factor
 
         self.dwcal_inv_covariance = weight_mat
+
+    data_vis_reshape = None
+    model_vis_reshape = None
+    vis_weights_reshape = None
+    def reshape_data(self, freq_ind, vis_pol_ind):
+        self.data_vis_reshape = np.reshape(
+            self.data_visibilities[:, :, freq_ind, vis_pol_ind],
+            (self.Ntimes, self.Nbls),
+        )
+        self.model_vis_reshape = np.reshape(
+            self.model_visibilities[:, :, freq_ind, vis_pol_ind],
+            (self.Ntimes, self.Nbls),
+        )
+        self.vis_weights_reshape = np.reshape(
+            self.visibility_weights[:, :, freq_ind, vis_pol_ind],
+            (self.Ntimes, self.Nbls),
+        )

--- a/calico/caldata.py
+++ b/calico/caldata.py
@@ -1242,19 +1242,33 @@ class CalData:
 
         self.dwcal_inv_covariance = weight_mat
 
-    data_vis_reshape = None
-    model_vis_reshape = None
-    vis_weights_reshape = None
+    gains_params = None
+    params_flattened = None
+    gains_real = None
+    gains_imag = None
+    def pack(self, freq_ind, feed_pol_ind):
+        self.gains_real = np.real(self.gains[self.ant_inds, freq_ind, feed_pol_ind])
+        self.gains_imag = np.imag(self.gains[self.ant_inds, freq_ind, feed_pol_ind])
+
+        return np.stack(
+            self.gains_real,
+            self.gains_imag,
+            axis=1,
+        ).flatten()
+
+    data_vis_reshaped = None
+    model_vis_reshaped = None
+    vis_weights_reshaped = None
     def reshape_data(self, freq_ind, vis_pol_ind):
-        self.data_vis_reshape = np.reshape(
+        self.data_vis_reshaped = np.reshape(
             self.data_visibilities[:, :, freq_ind, vis_pol_ind],
             (self.Ntimes, self.Nbls),
         )
-        self.model_vis_reshape = np.reshape(
+        self.model_vis_reshaped = np.reshape(
             self.model_visibilities[:, :, freq_ind, vis_pol_ind],
             (self.Ntimes, self.Nbls),
         )
-        self.vis_weights_reshape = np.reshape(
+        self.vis_weights_reshaped = np.reshape(
             self.visibility_weights[:, :, freq_ind, vis_pol_ind],
             (self.Ntimes, self.Nbls),
         )

--- a/calico/caldata.py
+++ b/calico/caldata.py
@@ -1242,8 +1242,6 @@ class CalData:
 
         self.dwcal_inv_covariance = weight_mat
 
-    gains_params = None
-    params_flattened = None
     gains_real = None
     gains_imag = None
     def pack(self, freq_ind, feed_pol_ind):
@@ -1251,8 +1249,10 @@ class CalData:
         self.gains_imag = np.imag(self.gains[self.ant_inds, freq_ind, feed_pol_ind])
 
         return np.stack(
-            self.gains_real,
-            self.gains_imag,
+            (
+                self.gains_real,
+                self.gains_imag,
+            ),
             axis=1,
         ).flatten()
 

--- a/calico/caldata.py
+++ b/calico/caldata.py
@@ -1258,3 +1258,19 @@ class CalData:
             self.visibility_weights[:, :, freq_ind, vis_pol_ind],
             (self.Ntimes, self.Nbls),
         )
+    
+    ant_inds = None
+    def set_ant_inds(self, freq_ind, feed_pol_ind):
+        vis_weights_summed = np.sum(
+            self.visibility_weights[:, :, freq_ind, feed_pol_ind], axis=0
+        )  # Sum over times
+        weight_per_ant = np.bincount(
+            self.ant1_inds,
+            weights=vis_weights_summed,
+            minlength=self.Nants,
+        ) + np.bincount(
+            self.ant2_inds,
+            weights=vis_weights_summed,
+            minlength=self.Nants,
+        )
+        self.ant_inds = np.where(weight_per_ant > 0.0)[0]

--- a/calico/calibration_optimization.py
+++ b/calico/calibration_optimization.py
@@ -603,14 +603,7 @@ def run_skycal_optimization_per_pol_single_freq(
         else:
             caldata_obj.set_ant_inds(freq_ind, feed_pol_ind)
 
-            gains_init_flattened = np.stack(
-                (
-                    np.real(caldata_obj.gains[caldata_obj.ant_inds, freq_ind, feed_pol_ind]),
-                    np.imag(caldata_obj.gains[caldata_obj.ant_inds, freq_ind, feed_pol_ind]),
-                ),
-                axis=1,
-            ).flatten()
-            #gains_init_flattened = caldata_obj.pack(freq_ind, feed_pol_ind)
+            gains_init_flattened = caldata_obj.pack(freq_ind, feed_pol_ind)
 
             caldata_obj.reshape_data(freq_ind, vis_pol_ind)
 

--- a/calico/calibration_optimization.py
+++ b/calico/calibration_optimization.py
@@ -10,8 +10,6 @@ def cost_skycal_wrapper(
     gains_flattened,
     caldata_obj,
     ant_inds,
-    # freq_ind,
-    # vis_pol_ind,
 ):
     """
     Wrapper for function cost_skycal. Reformats the input gains to be compatible
@@ -44,18 +42,6 @@ def cost_skycal_wrapper(
     if caldata_obj.gains_multiply_model:
         cost = cost_function_calculations.cost_skycal(
             gains,
-            # np.reshape(
-            #     caldata_obj.data_visibilities[:, :, freq_ind, vis_pol_ind],
-            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
-            # ),
-            # np.reshape(
-            #     caldata_obj.model_visibilities[:, :, freq_ind, vis_pol_ind],
-            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
-            # ),
-            # np.reshape(
-            #     caldata_obj.visibility_weights[:, :, freq_ind, vis_pol_ind],
-            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
-            # ),
             caldata_obj.data_vis_reshape,
             caldata_obj.model_vis_reshape,
             caldata_obj.vis_weights_reshape,
@@ -66,18 +52,6 @@ def cost_skycal_wrapper(
     else:
         cost = cost_function_calculations.cost_skycal(
             gains,
-            # np.reshape(
-            #     caldata_obj.model_visibilities[:, :, freq_ind, vis_pol_ind],
-            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
-            # ),
-            # np.reshape(
-            #     caldata_obj.data_visibilities[:, :, freq_ind, vis_pol_ind],
-            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
-            # ),
-            # np.reshape(
-            #     caldata_obj.visibility_weights[:, :, freq_ind, vis_pol_ind],
-            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
-            # ),
             caldata_obj.model_vis_reshape,
             caldata_obj.data_vis_reshape,
             caldata_obj.vis_weights_reshape,
@@ -92,8 +66,6 @@ def jacobian_skycal_wrapper(
     gains_flattened,
     caldata_obj,
     ant_inds,
-    # freq_ind,
-    # vis_pol_ind,
 ):
     """
     Wrapper for function jacobian_skycal. Reformats the input gains and
@@ -129,18 +101,6 @@ def jacobian_skycal_wrapper(
     if caldata_obj.gains_multiply_model:
         jac = cost_function_calculations.jacobian_skycal(
             gains,
-            # np.reshape(
-            #     caldata_obj.data_visibilities[:, :, freq_ind, vis_pol_ind],
-            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
-            # ),
-            # np.reshape(
-            #     caldata_obj.model_visibilities[:, :, freq_ind, vis_pol_ind],
-            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
-            # ),
-            # np.reshape(
-            #     caldata_obj.visibility_weights[:, :, freq_ind, vis_pol_ind],
-            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
-            # ),
             caldata_obj.data_vis_reshape,
             caldata_obj.model_vis_reshape,
             caldata_obj.vis_weights_reshape,
@@ -151,18 +111,6 @@ def jacobian_skycal_wrapper(
     else:
         jac = cost_function_calculations.jacobian_skycal(
             gains,
-            # np.reshape(
-            #     caldata_obj.model_visibilities[:, :, freq_ind, vis_pol_ind],
-            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
-            # ),
-            # np.reshape(
-            #     caldata_obj.data_visibilities[:, :, freq_ind, vis_pol_ind],
-            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
-            # ),
-            # np.reshape(
-            #     caldata_obj.visibility_weights[:, :, freq_ind, vis_pol_ind],
-            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
-            # ),
             caldata_obj.model_vis_reshape,
             caldata_obj.data_vis_reshape,
             caldata_obj.vis_weights_reshape,
@@ -180,8 +128,6 @@ def hessian_skycal_wrapper(
     gains_flattened,
     caldata_obj,
     ant_inds,
-    # freq_ind,
-    # vis_pol_ind,
 ):
     """
     Wrapper for function hessian_skycal. Reformats the input gains and
@@ -221,18 +167,6 @@ def hessian_skycal_wrapper(
             gains,
             caldata_obj.Nants,
             caldata_obj.Nbls,
-            # np.reshape(
-            #     caldata_obj.data_visibilities[:, :, freq_ind, vis_pol_ind],
-            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
-            # ),
-            # np.reshape(
-            #     caldata_obj.model_visibilities[:, :, freq_ind, vis_pol_ind],
-            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
-            # ),
-            # np.reshape(
-            #     caldata_obj.visibility_weights[:, :, freq_ind, vis_pol_ind],
-            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
-            # ),
             caldata_obj.data_vis_reshape,
             caldata_obj.model_vis_reshape,
             caldata_obj.vis_weights_reshape,
@@ -249,18 +183,6 @@ def hessian_skycal_wrapper(
             gains,
             caldata_obj.Nants,
             caldata_obj.Nbls,
-            # np.reshape(
-            #     caldata_obj.model_visibilities[:, :, freq_ind, vis_pol_ind],
-            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
-            # ),
-            # np.reshape(
-            #     caldata_obj.data_visibilities[:, :, freq_ind, vis_pol_ind],
-            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
-            # ),
-            # np.reshape(
-            #     caldata_obj.visibility_weights[:, :, freq_ind, vis_pol_ind],
-            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
-            # ),
             caldata_obj.model_vis_reshape,
             caldata_obj.data_vis_reshape,
             caldata_obj.vis_weights_reshape,

--- a/calico/calibration_optimization.py
+++ b/calico/calibration_optimization.py
@@ -42,9 +42,9 @@ def cost_skycal_wrapper(
     if caldata_obj.gains_multiply_model:
         cost = cost_function_calculations.cost_skycal(
             gains,
-            caldata_obj.data_vis_reshape,
-            caldata_obj.model_vis_reshape,
-            caldata_obj.vis_weights_reshape,
+            caldata_obj.data_vis_reshaped,
+            caldata_obj.model_vis_reshaped,
+            caldata_obj.vis_weights_reshaped,
             caldata_obj.ant1_inds,
             caldata_obj.ant2_inds,
             caldata_obj.lambda_val,
@@ -52,9 +52,9 @@ def cost_skycal_wrapper(
     else:
         cost = cost_function_calculations.cost_skycal(
             gains,
-            caldata_obj.model_vis_reshape,
-            caldata_obj.data_vis_reshape,
-            caldata_obj.vis_weights_reshape,
+            caldata_obj.model_vis_reshaped,
+            caldata_obj.data_vis_reshaped,
+            caldata_obj.vis_weights_reshaped,
             caldata_obj.ant1_inds,
             caldata_obj.ant2_inds,
             caldata_obj.lambda_val,
@@ -101,9 +101,9 @@ def jacobian_skycal_wrapper(
     if caldata_obj.gains_multiply_model:
         jac = cost_function_calculations.jacobian_skycal(
             gains,
-            caldata_obj.data_vis_reshape,
-            caldata_obj.model_vis_reshape,
-            caldata_obj.vis_weights_reshape,
+            caldata_obj.data_vis_reshaped,
+            caldata_obj.model_vis_reshaped,
+            caldata_obj.vis_weights_reshaped,
             caldata_obj.ant1_inds,
             caldata_obj.ant2_inds,
             caldata_obj.lambda_val,
@@ -111,9 +111,9 @@ def jacobian_skycal_wrapper(
     else:
         jac = cost_function_calculations.jacobian_skycal(
             gains,
-            caldata_obj.model_vis_reshape,
-            caldata_obj.data_vis_reshape,
-            caldata_obj.vis_weights_reshape,
+            caldata_obj.model_vis_reshaped,
+            caldata_obj.data_vis_reshaped,
+            caldata_obj.vis_weights_reshaped,
             caldata_obj.ant1_inds,
             caldata_obj.ant2_inds,
             caldata_obj.lambda_val,
@@ -167,9 +167,9 @@ def hessian_skycal_wrapper(
             gains,
             caldata_obj.Nants,
             caldata_obj.Nbls,
-            caldata_obj.data_vis_reshape,
-            caldata_obj.model_vis_reshape,
-            caldata_obj.vis_weights_reshape,
+            caldata_obj.data_vis_reshaped,
+            caldata_obj.model_vis_reshaped,
+            caldata_obj.vis_weights_reshaped,
             caldata_obj.ant1_inds,
             caldata_obj.ant2_inds,
             caldata_obj.lambda_val,
@@ -183,9 +183,9 @@ def hessian_skycal_wrapper(
             gains,
             caldata_obj.Nants,
             caldata_obj.Nbls,
-            caldata_obj.model_vis_reshape,
-            caldata_obj.data_vis_reshape,
-            caldata_obj.vis_weights_reshape,
+            caldata_obj.model_vis_reshaped,
+            caldata_obj.data_vis_reshaped,
+            caldata_obj.vis_weights_reshaped,
             caldata_obj.ant1_inds,
             caldata_obj.ant2_inds,
             caldata_obj.lambda_val,
@@ -610,6 +610,7 @@ def run_skycal_optimization_per_pol_single_freq(
                 ),
                 axis=1,
             ).flatten()
+            #gains_init_flattened = caldata_obj.pack(freq_ind, feed_pol_ind)
 
             caldata_obj.reshape_data(freq_ind, vis_pol_ind)
 

--- a/calico/calibration_optimization.py
+++ b/calico/calibration_optimization.py
@@ -10,8 +10,8 @@ def cost_skycal_wrapper(
     gains_flattened,
     caldata_obj,
     ant_inds,
-    freq_ind,
-    vis_pol_ind,
+    # freq_ind,
+    # vis_pol_ind,
 ):
     """
     Wrapper for function cost_skycal. Reformats the input gains to be compatible
@@ -44,18 +44,21 @@ def cost_skycal_wrapper(
     if caldata_obj.gains_multiply_model:
         cost = cost_function_calculations.cost_skycal(
             gains,
-            np.reshape(
-                caldata_obj.data_visibilities[:, :, freq_ind, vis_pol_ind],
-                (caldata_obj.Ntimes, caldata_obj.Nbls),
-            ),
-            np.reshape(
-                caldata_obj.model_visibilities[:, :, freq_ind, vis_pol_ind],
-                (caldata_obj.Ntimes, caldata_obj.Nbls),
-            ),
-            np.reshape(
-                caldata_obj.visibility_weights[:, :, freq_ind, vis_pol_ind],
-                (caldata_obj.Ntimes, caldata_obj.Nbls),
-            ),
+            # np.reshape(
+            #     caldata_obj.data_visibilities[:, :, freq_ind, vis_pol_ind],
+            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
+            # ),
+            # np.reshape(
+            #     caldata_obj.model_visibilities[:, :, freq_ind, vis_pol_ind],
+            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
+            # ),
+            # np.reshape(
+            #     caldata_obj.visibility_weights[:, :, freq_ind, vis_pol_ind],
+            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
+            # ),
+            caldata_obj.data_vis_reshape,
+            caldata_obj.model_vis_reshape,
+            caldata_obj.vis_weights_reshape,
             caldata_obj.ant1_inds,
             caldata_obj.ant2_inds,
             caldata_obj.lambda_val,
@@ -63,18 +66,21 @@ def cost_skycal_wrapper(
     else:
         cost = cost_function_calculations.cost_skycal(
             gains,
-            np.reshape(
-                caldata_obj.model_visibilities[:, :, freq_ind, vis_pol_ind],
-                (caldata_obj.Ntimes, caldata_obj.Nbls),
-            ),
-            np.reshape(
-                caldata_obj.data_visibilities[:, :, freq_ind, vis_pol_ind],
-                (caldata_obj.Ntimes, caldata_obj.Nbls),
-            ),
-            np.reshape(
-                caldata_obj.visibility_weights[:, :, freq_ind, vis_pol_ind],
-                (caldata_obj.Ntimes, caldata_obj.Nbls),
-            ),
+            # np.reshape(
+            #     caldata_obj.model_visibilities[:, :, freq_ind, vis_pol_ind],
+            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
+            # ),
+            # np.reshape(
+            #     caldata_obj.data_visibilities[:, :, freq_ind, vis_pol_ind],
+            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
+            # ),
+            # np.reshape(
+            #     caldata_obj.visibility_weights[:, :, freq_ind, vis_pol_ind],
+            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
+            # ),
+            caldata_obj.model_vis_reshape,
+            caldata_obj.data_vis_reshape,
+            caldata_obj.vis_weights_reshape,
             caldata_obj.ant1_inds,
             caldata_obj.ant2_inds,
             caldata_obj.lambda_val,
@@ -86,8 +92,8 @@ def jacobian_skycal_wrapper(
     gains_flattened,
     caldata_obj,
     ant_inds,
-    freq_ind,
-    vis_pol_ind,
+    # freq_ind,
+    # vis_pol_ind,
 ):
     """
     Wrapper for function jacobian_skycal. Reformats the input gains and
@@ -123,18 +129,21 @@ def jacobian_skycal_wrapper(
     if caldata_obj.gains_multiply_model:
         jac = cost_function_calculations.jacobian_skycal(
             gains,
-            np.reshape(
-                caldata_obj.data_visibilities[:, :, freq_ind, vis_pol_ind],
-                (caldata_obj.Ntimes, caldata_obj.Nbls),
-            ),
-            np.reshape(
-                caldata_obj.model_visibilities[:, :, freq_ind, vis_pol_ind],
-                (caldata_obj.Ntimes, caldata_obj.Nbls),
-            ),
-            np.reshape(
-                caldata_obj.visibility_weights[:, :, freq_ind, vis_pol_ind],
-                (caldata_obj.Ntimes, caldata_obj.Nbls),
-            ),
+            # np.reshape(
+            #     caldata_obj.data_visibilities[:, :, freq_ind, vis_pol_ind],
+            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
+            # ),
+            # np.reshape(
+            #     caldata_obj.model_visibilities[:, :, freq_ind, vis_pol_ind],
+            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
+            # ),
+            # np.reshape(
+            #     caldata_obj.visibility_weights[:, :, freq_ind, vis_pol_ind],
+            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
+            # ),
+            caldata_obj.data_vis_reshape,
+            caldata_obj.model_vis_reshape,
+            caldata_obj.vis_weights_reshape,
             caldata_obj.ant1_inds,
             caldata_obj.ant2_inds,
             caldata_obj.lambda_val,
@@ -142,18 +151,21 @@ def jacobian_skycal_wrapper(
     else:
         jac = cost_function_calculations.jacobian_skycal(
             gains,
-            np.reshape(
-                caldata_obj.model_visibilities[:, :, freq_ind, vis_pol_ind],
-                (caldata_obj.Ntimes, caldata_obj.Nbls),
-            ),
-            np.reshape(
-                caldata_obj.data_visibilities[:, :, freq_ind, vis_pol_ind],
-                (caldata_obj.Ntimes, caldata_obj.Nbls),
-            ),
-            np.reshape(
-                caldata_obj.visibility_weights[:, :, freq_ind, vis_pol_ind],
-                (caldata_obj.Ntimes, caldata_obj.Nbls),
-            ),
+            # np.reshape(
+            #     caldata_obj.model_visibilities[:, :, freq_ind, vis_pol_ind],
+            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
+            # ),
+            # np.reshape(
+            #     caldata_obj.data_visibilities[:, :, freq_ind, vis_pol_ind],
+            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
+            # ),
+            # np.reshape(
+            #     caldata_obj.visibility_weights[:, :, freq_ind, vis_pol_ind],
+            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
+            # ),
+            caldata_obj.model_vis_reshape,
+            caldata_obj.data_vis_reshape,
+            caldata_obj.vis_weights_reshape,
             caldata_obj.ant1_inds,
             caldata_obj.ant2_inds,
             caldata_obj.lambda_val,
@@ -168,8 +180,8 @@ def hessian_skycal_wrapper(
     gains_flattened,
     caldata_obj,
     ant_inds,
-    freq_ind,
-    vis_pol_ind,
+    # freq_ind,
+    # vis_pol_ind,
 ):
     """
     Wrapper for function hessian_skycal. Reformats the input gains and
@@ -209,18 +221,21 @@ def hessian_skycal_wrapper(
             gains,
             caldata_obj.Nants,
             caldata_obj.Nbls,
-            np.reshape(
-                caldata_obj.data_visibilities[:, :, freq_ind, vis_pol_ind],
-                (caldata_obj.Ntimes, caldata_obj.Nbls),
-            ),
-            np.reshape(
-                caldata_obj.model_visibilities[:, :, freq_ind, vis_pol_ind],
-                (caldata_obj.Ntimes, caldata_obj.Nbls),
-            ),
-            np.reshape(
-                caldata_obj.visibility_weights[:, :, freq_ind, vis_pol_ind],
-                (caldata_obj.Ntimes, caldata_obj.Nbls),
-            ),
+            # np.reshape(
+            #     caldata_obj.data_visibilities[:, :, freq_ind, vis_pol_ind],
+            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
+            # ),
+            # np.reshape(
+            #     caldata_obj.model_visibilities[:, :, freq_ind, vis_pol_ind],
+            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
+            # ),
+            # np.reshape(
+            #     caldata_obj.visibility_weights[:, :, freq_ind, vis_pol_ind],
+            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
+            # ),
+            caldata_obj.data_vis_reshape,
+            caldata_obj.model_vis_reshape,
+            caldata_obj.vis_weights_reshape,
             caldata_obj.ant1_inds,
             caldata_obj.ant2_inds,
             caldata_obj.lambda_val,
@@ -234,18 +249,21 @@ def hessian_skycal_wrapper(
             gains,
             caldata_obj.Nants,
             caldata_obj.Nbls,
-            np.reshape(
-                caldata_obj.model_visibilities[:, :, freq_ind, vis_pol_ind],
-                (caldata_obj.Ntimes, caldata_obj.Nbls),
-            ),
-            np.reshape(
-                caldata_obj.data_visibilities[:, :, freq_ind, vis_pol_ind],
-                (caldata_obj.Ntimes, caldata_obj.Nbls),
-            ),
-            np.reshape(
-                caldata_obj.visibility_weights[:, :, freq_ind, vis_pol_ind],
-                (caldata_obj.Ntimes, caldata_obj.Nbls),
-            ),
+            # np.reshape(
+            #     caldata_obj.model_visibilities[:, :, freq_ind, vis_pol_ind],
+            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
+            # ),
+            # np.reshape(
+            #     caldata_obj.data_visibilities[:, :, freq_ind, vis_pol_ind],
+            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
+            # ),
+            # np.reshape(
+            #     caldata_obj.visibility_weights[:, :, freq_ind, vis_pol_ind],
+            #     (caldata_obj.Ntimes, caldata_obj.Nbls),
+            # ),
+            caldata_obj.model_vis_reshape,
+            caldata_obj.data_vis_reshape,
+            caldata_obj.vis_weights_reshape,
             caldata_obj.ant1_inds,
             caldata_obj.ant2_inds,
             caldata_obj.lambda_val,
@@ -681,12 +699,14 @@ def run_skycal_optimization_per_pol_single_freq(
                 axis=1,
             ).flatten()
 
+            caldata_obj.reshape_data(freq_ind, vis_pol_ind)
+
             # Minimize the cost function
             start_optimize = time.time()
             result = scipy.optimize.minimize(
                 cost_skycal_wrapper,
                 gains_init_flattened,
-                args=(caldata_obj, ant_inds, freq_ind, vis_pol_ind),
+                args=(caldata_obj, ant_inds),
                 method="Newton-CG",
                 jac=jacobian_skycal_wrapper,
                 hess=hessian_skycal_wrapper,

--- a/calico/calibration_optimization.py
+++ b/calico/calibration_optimization.py
@@ -13,6 +13,18 @@ from calico import cost_function_calculations
     for those -- also RR, RI, and II -- as well as cross terms for u and g 
     that will constitute additional expected elements in that dimension of
     the array, handled similarly. This algorithm might update in the future.
+
+    Parameters
+    ----------
+    hess_arrays : array of float
+        Array of Hessians pieces with gain 
+    Nants_unflagged : int
+        Length of array of indexed antennas
+
+    Returns
+    -------
+    hess_flattened : array of float
+        Hessian of the cost function, shape (2*Nants_unflagged, 2*Nants_unflagged,).
 """
 def flatten_hessian(
     hess_arrays,

--- a/calico/calibration_optimization.py
+++ b/calico/calibration_optimization.py
@@ -659,6 +659,8 @@ def run_skycal_optimization_per_pol_single_freq(
         Fit gain values. Shape (Nants, 1, N_feed_pols,).
     """
 
+    print("***NEW CAL***")
+
     gains_fit = np.full(
         (caldata_obj.Nants, caldata_obj.N_feed_pols),
         np.nan + 1j * np.nan,

--- a/calico/tests.py
+++ b/calico/tests.py
@@ -1104,8 +1104,12 @@ class TestStringMethods(unittest.TestCase):
             axis=1,
         ).flatten()
 
+        # hess = calibration_optimization.hessian_skycal_wrapper(
+        #     gains_flattened, caldata_obj, np.arange(caldata_obj.Nants), 0, 0
+        # )
+        caldata_obj.reshape_data(0,0)
         hess = calibration_optimization.hessian_skycal_wrapper(
-            gains_flattened, caldata_obj, np.arange(caldata_obj.Nants), 0, 0
+            gains_flattened, caldata_obj, np.arange(caldata_obj.Nants),
         )
 
         np.testing.assert_allclose(hess - np.conj(hess.T), 0.0 + 1j * 0.0)


### PR DESCRIPTION
While working on UniCal implementation, basing it off the existing SkyCal implementation, it seemed worthwhile to abstract some of the functions to accommodate u-params as well as gains params.

My understanding is we want to facilitate additional calibration implementations in the future for some future user. Therefore they could call these functions in their own calibration functions. Moving these functions and relevant parameters onto the CalData object seemed most sensible. For now, they're only SkyCal, with potential to be expanded with u-params.

Additionally, I moved the reshape function being called by the optimization function wrappers three times -- once per cost, jac, and hess -- into a function on the object called once by the calibration function before running the optimizer.

I don't think we have automatic GH unit tests set up yet but it's passing all of the ones in tests.py on my machine (MacOS, M-series CPU).

